### PR TITLE
[CLI] fix ignored `run` `--host` and `--port` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.1] - 2024-07-04
+
 ### Fixed
 
 - [CLI] fix ignored `run` `--host` and `--port` options
@@ -41,7 +43,8 @@ and this project adheres to
 - Implement CSV output format
 - Implement Parquet output format
 
-[unreleased]: https://github.com/jmaupetit/data7/compare/v0.4.0...main
+[unreleased]: https://github.com/jmaupetit/data7/compare/v0.4.1...main
+[0.4.1]: https://github.com/jmaupetit/data7/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jmaupetit/data7/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jmaupetit/data7/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jmaupetit/data7/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- [CLI] fix ignored `run` `--host` and `--port` options
+
 ## [0.4.0] - 2024-07-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data7"
-version = "0.4.0"
+version = "0.4.1"
 description = "Data7 streams CSV/Parquet datasets over HTTP from SQL queries."
 authors = ["Julien Maupetit <julien@maupetit.net>"]
 license = "MIT"

--- a/src/data7/cli.py
+++ b/src/data7/cli.py
@@ -203,16 +203,8 @@ def run(  # noqa: PLR0913
     """Run data7 web server."""
     default_host = "localhost"
     default_port = 8000
-    host = (
-        data7.config.settings.get("HOST", default_host)
-        if host is None
-        else default_host
-    )
-    port = (
-        data7.config.settings.get("PORT", default_port)
-        if port is None
-        else default_port
-    )
+    host = data7.config.settings.get("HOST", default_host) if host is None else host
+    port = data7.config.settings.get("PORT", default_port) if port is None else port
     # Configure logging
     log_config = copy.copy(uvicorn.config.LOGGING_CONFIG)
     log_config["loggers"]["data7.app"] = {


### PR DESCRIPTION
## Purpose

When using the `data7 run` command using the `--host` or `--port` option, none of the aforementioned option were considered.

## Proposal

- [x] fix defaults switch
