### PR TITLE
Various improvements

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -41,4 +41,4 @@ jobs:
         working-directory: /tmp/data7
         env:
           ENV_FOR_DYNACONF: development
-        run: timeout --preserve-status 5 data7 run
+        run: timeout --preserve-status 5 data7 run --reload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore datasets with a query returning no results instead of raising an error
+
 ### Fixed
 
 - [CLI] `run` command `reload` option should not be enabled by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- [CLI] `run` command `reload` option should not be enabled by default
+
 ## [0.4.1] - 2024-07-04
 
 ### Fixed

--- a/src/data7/app.py
+++ b/src/data7/app.py
@@ -72,7 +72,11 @@ async def populate_datasets() -> List[Dataset]:
             ) from exc
         # Query returns no result, we cannot set fields.
         if row is None:
-            raise ValueError(f"Dataset '{dataset.basename}' query returned no result")
+            logger.warning(
+                "'%s' query returned no result, dataset will be ignored",
+                dataset.basename,
+            )
+            continue
         # Set fields from database query result
         dataset.fields = list(row._mapping.keys())
 

--- a/src/data7/cli.py
+++ b/src/data7/cli.py
@@ -194,7 +194,7 @@ def check():
 def run(  # noqa: PLR0913
     host: Optional[str] = None,
     port: Optional[int] = None,
-    reload: bool = True,
+    reload: bool = False,
     workers: Optional[int] = None,
     root_path: str = "",
     proxy_headers: bool = False,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -92,10 +92,8 @@ async def test_populate_datasets_with_invalid_query(monkeypatch):
         ],
     )
 
-    with pytest.raises(
-        ValueError, match="Dataset 'employees' query returned no result"
-    ):
-        await populate_datasets()
+    datasets = await populate_datasets()
+    assert len(datasets) == 0
 
     employees_query = (
         "SELECT "


### PR DESCRIPTION
## Purpose

When doing our first [integration on a real-life project](https://github.com/MTES-MCT/qualicharge/pull/116), we noticed that default behavior needed more tuning.

## Proposal

- [x] CLI: switched `run` reload default to False
- [x] ignore datasets with no results

