### PR TITLE
🔧(project) group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        applies-to: "version-updates"
+        patterns: "*"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        applies-to: "version-updates"
+        patterns: "*"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Proposal

Having one PR per patch or minor upgrade is not efficient, we can group them on a weekly PR. And focus on major upgrades instead.
