### PR TITLE
🔖(minor) bump release to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-09-09
+
 ### Changed
 
 - Upgrade dynaconf to 3.2.6
@@ -18,7 +20,7 @@ and this project adheres to
 - Upgrade starlette to 0.38.5
 - Upgrade typer to 0.12.5
 - Upgrade uvicorn to 0.30.6
-- Recommand using psycopg3 driver for PostgreSQL
+- Recommend using psycopg3 driver for PostgreSQL
 
 ## [0.6.0] - 2024-07-16
 
@@ -75,7 +77,8 @@ and this project adheres to
 - Implement CSV output format
 - Implement Parquet output format
 
-[unreleased]: https://github.com/jmaupetit/data7/compare/v0.6.0...main
+[unreleased]: https://github.com/jmaupetit/data7/compare/v0.7.0...main
+[0.7.0]: https://github.com/jmaupetit/data7/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jmaupetit/data7/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/jmaupetit/data7/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/jmaupetit/data7/compare/v0.4.0...v0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data7"
-version = "0.6.0"
+version = "0.7.0"
 description = "Data7 streams CSV/Parquet datasets over HTTP from SQL queries."
 authors = ["Julien Maupetit <julien@maupetit.net>"]
 license = "MIT"


### PR DESCRIPTION
### Changed

- Upgrade dynaconf to 3.2.6
- Upgrade pyarrow to 17.0.0
- Upgrade pyinstrument to 0.5.7
- Upgrade sentry-sdk to 2.13.0
- Upgrade SQLAlchemy to 2.0.32
- Upgrade starlette to 0.38.5
- Upgrade typer to 0.12.5
- Upgrade uvicorn to 0.30.6
- Recommend using psycopg3 driver for PostgreSQL
