### PR TITLE
Allow sentry profiling configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.9.0] - 2025-01-07
+
 ### Changed
 
 - Upgrade matplotlib to 3.10.0
@@ -99,7 +101,8 @@ and this project adheres to
 - Implement CSV output format
 - Implement Parquet output format
 
-[unreleased]: https://github.com/jmaupetit/data7/compare/v0.8.0...main
+[unreleased]: https://github.com/jmaupetit/data7/compare/v0.9.0...main
+[0.9.0]: https://github.com/jmaupetit/data7/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jmaupetit/data7/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jmaupetit/data7/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jmaupetit/data7/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - Upgrade starlette to 0.41.2
 - Upgrade typer to 0.15.1
 - Upgrade uvicorn to 0.32.1
+- Improve Sentry configuration (toggle tracing and configure profiling)
 
 ## [0.8.0] - 2024-10-17
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,9 +221,27 @@ Default: `None`
 
 ---
 
+#### `SENTRY_ENABLE_TRACING`
+
+Toggle Sentry performance tracking feature.
+
+Default: `True`
+
+---
+
 #### `SENTRY_TRACES_SAMPLE_RATE`
 
-The sample rate of traces sent to sentry: 1.0 means 100% while 0.1 means 10%.
+The sample rate of traces sent to sentry: 1.0 means 100% while 0.1 means 10%. It
+should be adapted for production.
+
+Default: `1.0`
+
+---
+
+#### `SENTRY_PROFILES_SAMPLE_RATE`
+
+The sample rate of profiles sent to sentry: 1.0 means 100% while 0.1 means 10%.
+It should be adapted for production.
 
 Default: `1.0`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data7"
-version = "0.8.0"
+version = "0.9.0"
 description = "Data7 streams CSV/Parquet datasets over HTTP from SQL queries."
 authors = ["Julien Maupetit <julien@maupetit.net>"]
 license = "MIT"

--- a/src/data7/app.py
+++ b/src/data7/app.py
@@ -249,8 +249,9 @@ async def lifespan(app):
     if settings.SENTRY_DSN is not None:
         sentry_sdk.init(
             dsn=str(settings.SENTRY_DSN),
-            enable_tracing=True,
+            enable_tracing=settings.SENTRY_ENABLE_TRACING,
             traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+            profiles_sample_rate=settings.SENTRY_PROFILES_SAMPLE_RATE,
             release=importlib.metadata.version("data7"),
             environment=settings.EXECUTION_ENVIRONMENT,
             integrations=[

--- a/src/data7/settings.yaml.dist
+++ b/src/data7/settings.yaml.dist
@@ -27,7 +27,9 @@ default:
 
   # Sentry
   sentry_dsn: null
+  sentry_enable_tracing: true
   sentry_traces_sample_rate: 1.0
+  sentry_profiles_sample_rate: 1.0
 
   # Pyinstrument
   profiling: false
@@ -45,7 +47,9 @@ production:
 
   # Sentry
   # sentry_dsn:
+  # sentry_enable_tracing: true
   # sentry_traces_sample_rate: 1.0
+  # sentry_profiles_sample_rate: 1.0
 
   # Pyinstrument
   profiling: false


### PR DESCRIPTION
## Purpose

Sentry is not fully customizable using provided configurtation.

## Proposal

- [x] add `SENTRY_ENABLE_TRACING` setting
- [x] add `SENTRY_PROFILES_SAMPLE_RATE` setting
