### PR TITLE
Feature: use streamers from the CLI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,3 +42,12 @@ jobs:
         env:
           ENV_FOR_DYNACONF: development
         run: timeout --preserve-status 5 data7 run --reload
+      - name: Stream datasets
+        working-directory: /tmp/data7
+        env:
+          ENV_FOR_DYNACONF: development
+        run: |
+          data7 stream csv invoices > /dev/null
+          data7 stream parquet invoices > /dev/null
+          data7 stream csv tracks > /dev/null
+          data7 stream parquet tracks > /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Stream datasets from the CLI using the new `stream` command
+
 ### Changed
+
+#### Dependencies
 
 - Upgrade dynaconf to 3.2.10
 - Upgrade pandas to 2.2.3
@@ -24,17 +30,22 @@ and this project adheres to
 
 ### Changed
 
+- Improve Sentry configuration (toggle tracing and configure profiling)
+
+#### Dependencies
+
 - Upgrade matplotlib to 3.10.0
 - Upgrade pyarrow to 18.2.0
 - Upgrade sentry-sdk to 2.18.0
 - Upgrade starlette to 0.41.2
 - Upgrade typer to 0.15.1
 - Upgrade uvicorn to 0.32.1
-- Improve Sentry configuration (toggle tracing and configure profiling)
 
 ## [0.8.0] - 2024-10-17
 
 ### Changed
+
+#### Dependencies
 
 - Upgrade anyio to 4.6.2.post1
 - Upgrade psycopg to 3.2.3
@@ -48,6 +59,10 @@ and this project adheres to
 
 ### Changed
 
+- Recommend using psycopg3 driver for PostgreSQL
+
+#### Dependencies
+
 - Upgrade dynaconf to 3.2.6
 - Upgrade pyarrow to 17.0.0
 - Upgrade pyinstrument to 0.5.7
@@ -56,7 +71,6 @@ and this project adheres to
 - Upgrade starlette to 0.38.5
 - Upgrade typer to 0.12.5
 - Upgrade uvicorn to 0.30.6
-- Recommend using psycopg3 driver for PostgreSQL
 
 ## [0.6.0] - 2024-07-16
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,7 @@
+# Command Line Interface (CLI)
+
+::: mkdocs-click
+    :module: data7.cli
+    :command: cli_click
+    :depth: 1
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ repo_name: jmaupetit/data7
 nav:
   - Introduction: "index.md"
   - Tutorial: "tutorial.md"
+  - Command Line Interface: "commands.md"
   - Configuration: "configuration.md"
   - Contribute:
       - Code of conduct: "code_of_conduct.md"
@@ -45,6 +46,7 @@ theme:
 
 markdown_extensions:
   - admonition
+  - mkdocs-click
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -1181,6 +1181,22 @@ i18n = ["babel (>=2.9.0)"]
 min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4) ; platform_system == \"Windows\"", "ghp-import (==1.0)", "importlib-metadata (==4.4) ; python_version < \"3.10\"", "jinja2 (==2.11.1)", "markdown (==3.3.6)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "mkdocs-get-deps (==0.2.0)", "packaging (==20.5)", "pathspec (==0.11.1)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "watchdog (==2.0)"]
 
 [[package]]
+name = "mkdocs-click"
+version = "0.9.0"
+description = "An MkDocs extension to generate documentation for Click command line applications"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "mkdocs_click-0.9.0-py3-none-any.whl", hash = "sha256:5208e828f4f68f63c847c1ef7be48edee9964090390afc8f5b3d4cbe5ea9bbed"},
+    {file = "mkdocs_click-0.9.0.tar.gz", hash = "sha256:6050917628d4740517541422b607404d044117bc31b770c4f9e9e1939a50c908"},
+]
+
+[package.dependencies]
+click = ">=8.1"
+markdown = ">=3.3"
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 description = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
@@ -2769,4 +2785,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "6544ac7f8c2163d35cdcb274a82d42be7ec23e430ac39cc067bb54c655e8d2bd"
+content-hash = "11408954197d920adf1a2ca1e7ab5eb5611e88b45e06e6176a3260374bbc2a2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ asyncpg = "^0.30.0"
 black = ">=24.4.2,<26.0.0"
 databases = {extras = ["aiosqlite"], version = "^0.9.0"}
 matplotlib = "^3.10.0"
+mkdocs-click = "^0.9.0"
 mkdocs-material = "^9.5.27"
 mypy = "^1.13.0"
 psycopg = {extras = ["binary", "pool"], version = "^3.2.1"}

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -90,7 +90,7 @@ def _pd_sql2csv(dataset: Dataset, chunksize: int = 5000) -> float:
     """sql2any wrapper to handled database connection."""
     profiler.reset()
     profiler.start()
-    for _ in pd_sql2csv(dataset, chunksize):
+    for _ in pd_sql2csv(engine, dataset, chunksize):
         pass
     profiler.stop()
     return profiler.last_session.duration if profiler.last_session else 0.0

--- a/src/data7/app.py
+++ b/src/data7/app.py
@@ -3,7 +3,6 @@
 import contextlib
 import importlib.metadata
 import logging
-from enum import StrEnum
 from pathlib import PurePath
 from typing import Callable, Generator, List, Optional, Tuple
 
@@ -22,25 +21,11 @@ from starlette.routing import Route
 from starlette.status import HTTP_501_NOT_IMPLEMENTED
 
 from .config import settings
-from .models import Dataset
+from .models import Dataset, Extension, MimeType
 from .streamers import sql2csv, sql2parquet
 from .utils import populate_datasets
 
 logger = logging.getLogger(__name__)
-
-
-class Extension(StrEnum):
-    """Supported formats extensions."""
-
-    CSV = "csv"
-    PARQUET = "parquet"
-
-
-class MimeType(StrEnum):
-    """MimeTypes for supported formats."""
-
-    CSV = "text/csv"
-    PARQUET = "application/vnd.apache.parquet"
 
 
 def get_dataset_from_url(

--- a/src/data7/cli.py
+++ b/src/data7/cli.py
@@ -193,7 +193,7 @@ def check():
 
 @cli.command()
 def stream(extension: Extension, name: str):
-    """Stream selected dataset."""
+    """Stream a dataset given its name and a selected extension."""
     datasets = data7.config.settings.datasets
     names = [d.basename for d in datasets]
     if name not in names:
@@ -254,3 +254,8 @@ def run(  # noqa: PLR0913
         log_level=log_level,
         log_config=log_config,
     )
+
+
+# Get a provisionned Click instance to automatically generate CLI commands documentation
+# using the mkdocs-click module
+cli_click = typer.main.get_command(cli)

--- a/src/data7/data7.yaml.dist
+++ b/src/data7/data7.yaml.dist
@@ -21,7 +21,7 @@ development:
     - basename: invoices
       query: "SELECT * FROM Invoice"
     - basename: tracks
-      query: >-
+      query: |
         SELECT Artist.Name as artist, Album.Title as title, Track.Name as track
         FROM Artist
         INNER JOIN Album ON Artist.ArtistId = Album.ArtistId
@@ -31,5 +31,19 @@ development:
 # ---- TESTING ---------------------------------
 testing:
   datasets:
-    - basename: dummy
-      query: "SELECT 1"
+    - basename: employees
+      query: |
+        SELECT
+          LastName as last_name,
+          FirstName as first_name,
+          city as city
+        FROM Employee
+        LIMIT 20
+    - basename: customers
+      query: |
+        SELECT
+          LastName as last_name,
+          FirstName as first_name,
+          Company as company
+        FROM Customer
+        LIMIT 10

--- a/src/data7/models.py
+++ b/src/data7/models.py
@@ -1,0 +1,17 @@
+"""Data7 models module."""
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Dataset:
+    """Dataset model."""
+
+    basename: str
+    query: str
+    # Indexes can be defined for a dataset query
+    indexes: Optional[List[str]] = None

--- a/src/data7/models.py
+++ b/src/data7/models.py
@@ -2,9 +2,24 @@
 
 import logging
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+class Extension(StrEnum):
+    """Supported formats extensions."""
+
+    CSV = "csv"
+    PARQUET = "parquet"
+
+
+class MimeType(StrEnum):
+    """MimeTypes for supported formats."""
+
+    CSV = "text/csv"
+    PARQUET = "application/vnd.apache.parquet"
 
 
 @dataclass

--- a/src/data7/streamers.py
+++ b/src/data7/streamers.py
@@ -1,0 +1,72 @@
+"""Data7 streamers module."""
+
+import logging
+from io import BytesIO
+from typing import Generator
+
+import pandas as pd
+import pyarrow as pa
+from pyarrow import parquet as pq
+from sqlalchemy import Engine
+
+from .config import settings
+from .models import Dataset
+
+logger = logging.getLogger(__name__)
+
+
+def sql2parquet(engine: Engine, dataset: Dataset, chunksize: int = 5000) -> Generator:
+    """Stream SQL rows to parquet."""
+    logger.debug("SQL query: %s", dataset.query)
+    output = BytesIO()
+
+    def get_batch(output: BytesIO) -> bytes:
+        """Get wrote batch content."""
+        size = output.tell()
+        output.seek(0)
+        return output.read(size)
+
+    with engine.connect() as conn:
+        # Get schema from a subset of data
+        schema = pa.Schema.from_pandas(
+            next(
+                pd.read_sql_query(
+                    dataset.query,
+                    conn,
+                    chunksize=settings.SCHEMA_SNIFFER_SIZE,
+                    dtype_backend=settings.DEFAULT_DTYPE_BACKEND,
+                    index_col=dataset.indexes,
+                )
+            )
+        )
+        writer = pq.ParquetWriter(output, schema=schema, compression="GZIP")
+
+        for chunk in pd.read_sql_query(
+            dataset.query,
+            conn,
+            chunksize=chunksize,
+            dtype_backend=settings.DEFAULT_DTYPE_BACKEND,
+            index_col=dataset.indexes,
+        ):
+            writer.write_batch(
+                pa.RecordBatch.from_pandas(chunk, schema=schema, preserve_index=True)
+            )
+            yield get_batch(output)
+            output.seek(0)
+
+    writer.close()
+    # When closing file, the parquet writer adds required footer and magic bytes. We
+    # need those so that the Parqet file is readable.
+    yield get_batch(output)
+    output.close()
+
+
+def sql2csv(
+    engine: Engine, dataset: Dataset, chunksize: int = 5000
+) -> Generator[str, None, None]:
+    """Stream SQL rows to CSV."""
+    with engine.connect() as conn:
+        for c, chunk in enumerate(
+            pd.read_sql_query(dataset.query, conn, chunksize=chunksize)
+        ):
+            yield chunk.to_csv(header=True if c == 0 else False, index=False)

--- a/src/data7/utils.py
+++ b/src/data7/utils.py
@@ -1,0 +1,44 @@
+"""Data7 utils module."""
+
+import logging
+from typing import List
+
+from sqlalchemy import Engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.sql import text
+
+from .config import settings
+from .models import Dataset
+
+logger = logging.getLogger(__name__)
+
+
+def populate_datasets(engine: Engine) -> List[Dataset]:
+    """Validate configured datasets and get sql query expected field names."""
+    logging.debug("Will populate datasets given configuration...")
+    datasets = []
+
+    with engine.connect() as conn:
+        for raw_dataset in settings.datasets:
+            dataset = Dataset(**raw_dataset)
+
+            # Validate database query and get expected field names
+            try:
+                result = conn.execute(text(dataset.query))
+            except OperationalError as exc:
+                raise ValueError(
+                    f"Dataset '{dataset.basename}' query failed, maybe SQL is invalid"
+                ) from exc
+
+            # Query returns no result, we cannot set fields.
+            if result.scalar() is None:
+                logger.warning(
+                    "'%s' query returned no result, dataset will be ignored",
+                    dataset.basename,
+                )
+                continue
+
+            datasets.append(dataset)
+
+    logger.info("Active datasets: %s", ", ".join(d.basename for d in datasets))
+    return datasets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Tests configuration."""
 
 import pytest
+from sqlalchemy import create_engine
 from typer.testing import CliRunner
 
 from data7.config import settings
@@ -10,6 +11,12 @@ from data7.config import settings
 def set_test_settings():
     """Force testing environment for settings."""
     settings.configure(FORCE_ENV_FOR_DYNACONF="testing")
+
+
+@pytest.fixture
+def db_engine():
+    """Get database engine."""
+    yield create_engine(settings.DATABASE_URL)
 
 
 @pytest.fixture

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,9 +2,7 @@
 
 from pathlib import PurePath
 
-import pyarrow as pa
 import pytest
-from pyarrow import parquet
 from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND, HTTP_501_NOT_IMPLEMENTED
 from starlette.testclient import TestClient
 
@@ -14,108 +12,8 @@ from data7.app import (
     app,
     get_dataset_from_url,
     get_routes_from_datasets,
-    populate_datasets,
-    sql2csv,
-    sql2parquet,
     stream_dataset,
 )
-from data7.config import settings
-
-
-def test_populate_datasets(monkeypatch):
-    """Test the populate_datasets function."""
-    employees_query = (
-        "SELECT "
-        "LastName as last_name, "
-        "FirstName as first_name, "
-        "city as city "
-        "FROM Employee"
-    )
-
-    customers_query = (
-        "SELECT "
-        "LastName as last_name, "
-        "FirstName as first_name, "
-        "Company as company "
-        "FROM Customer"
-    )
-
-    monkeypatch.setattr(
-        settings,
-        "datasets",
-        [
-            {
-                "basename": "employees",
-                "query": employees_query,
-            },
-            {
-                "basename": "customers",
-                "query": customers_query,
-            },
-        ],
-    )
-    datasets = populate_datasets()
-    assert datasets == [
-        Dataset(
-            basename="employees",
-            query=employees_query,
-        ),
-        Dataset(
-            basename="customers",
-            query=customers_query,
-        ),
-    ]
-
-
-def test_populate_datasets_with_invalid_query(monkeypatch):
-    """Test the populate_datasets function when user defined an invalid query."""
-    employees_query = (
-        "SELECT "
-        "LastName as last_name, "
-        "FirstName as first_name, "
-        "city as city "
-        "FROM Employee "
-        "WHERE LastName = 'Doe'"
-    )
-
-    monkeypatch.setattr(
-        settings,
-        "datasets",
-        [
-            {
-                "basename": "employees",
-                "query": employees_query,
-            },
-        ],
-    )
-
-    datasets = populate_datasets()
-    assert len(datasets) == 0
-
-    employees_query = (
-        "SELECT "
-        "LastName as last_name, "
-        "FirstName as first_name, "
-        "city as city "
-        "FROM Employe "
-        "WHERE LastName = 'Doe'"
-    )
-
-    monkeypatch.setattr(
-        settings,
-        "datasets",
-        [
-            {
-                "basename": "employees",
-                "query": employees_query,
-            },
-        ],
-    )
-
-    with pytest.raises(
-        ValueError, match="Dataset 'employees' query failed, maybe SQL is invalid"
-    ):
-        populate_datasets()
 
 
 def test_get_dataset_from_url():
@@ -191,56 +89,6 @@ def test_get_routes_from_datasets():
     assert routes[1].path == "/d/employees.parquet"
     assert routes[2].path == "/d/customers.csv"
     assert routes[3].path == "/d/customers.parquet"
-
-
-def test_sql2csv():
-    """Test sql2csv function."""
-    dataset = Dataset(
-        basename="customers",
-        query=(
-            "SELECT "
-            "LastName as last_name, "
-            "FirstName as first_name, "
-            "Company as company "
-            "FROM Customer "
-            "ORDER BY last_name, first_name"
-        ),
-    )
-
-    n_customers = 59
-    output = list(filter(lambda x: len(x), "".join(sql2csv(dataset)).split("\n")))
-    assert len(output) == n_customers + 1
-    assert output[0] == "last_name,first_name,company"
-    assert output[1] == "Almeida,Roberto,Riotur"
-    assert output[-1] == "Zimmermann,Fynn,"
-
-
-def test_sql2parquet():
-    """Test sql2parquet function."""
-    dataset = Dataset(
-        basename="customers",
-        query=(
-            "SELECT "
-            "LastName as last_name, "
-            "FirstName as first_name, "
-            "Company as company "
-            "FROM Customer "
-            "ORDER BY last_name, first_name"
-        ),
-    )
-
-    n_customers = 59
-    with pa.BufferReader(b"".join(sql2parquet(dataset, chunksize=10))) as stream:
-        customers = parquet.ParquetFile(stream)
-        assert customers.metadata.num_rows == n_customers
-
-        table = customers.read()
-        assert str(table["last_name"][0]) == "Almeida"
-        assert str(table["first_name"][0]) == "Roberto"
-        assert str(table["company"][0]) == "Riotur"
-        assert str(table["last_name"][-1]) == "Zimmermann"
-        assert str(table["first_name"][-1]) == "Fynn"
-        assert str(table["company"][-1]) == "None"
 
 
 def test_stream_dataset_route():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,13 +7,12 @@ from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND, HTTP_501_NOT_IMPLE
 from starlette.testclient import TestClient
 
 from data7.app import (
-    Dataset,
-    Extension,
     app,
     get_dataset_from_url,
     get_routes_from_datasets,
     stream_dataset,
 )
+from data7.models import Dataset, Extension
 
 
 def test_get_dataset_from_url():

--- a/tests/test_streamers.py
+++ b/tests/test_streamers.py
@@ -1,0 +1,61 @@
+"""Tests for the data7.streamers module."""
+
+import pyarrow as pa
+from pyarrow import parquet
+
+from data7.models import Dataset
+from data7.streamers import sql2csv, sql2parquet
+
+
+def test_sql2csv(db_engine):
+    """Test sql2csv function."""
+    dataset = Dataset(
+        basename="customers",
+        query=(
+            "SELECT "
+            "LastName as last_name, "
+            "FirstName as first_name, "
+            "Company as company "
+            "FROM Customer "
+            "ORDER BY last_name, first_name"
+        ),
+    )
+
+    n_customers = 59
+    output = list(
+        filter(lambda x: len(x), "".join(sql2csv(db_engine, dataset)).split("\n"))
+    )
+    assert len(output) == n_customers + 1
+    assert output[0] == "last_name,first_name,company"
+    assert output[1] == "Almeida,Roberto,Riotur"
+    assert output[-1] == "Zimmermann,Fynn,"
+
+
+def test_sql2parquet(db_engine):
+    """Test sql2parquet function."""
+    dataset = Dataset(
+        basename="customers",
+        query=(
+            "SELECT "
+            "LastName as last_name, "
+            "FirstName as first_name, "
+            "Company as company "
+            "FROM Customer "
+            "ORDER BY last_name, first_name"
+        ),
+    )
+
+    n_customers = 59
+    with pa.BufferReader(
+        b"".join(sql2parquet(db_engine, dataset, chunksize=10))
+    ) as stream:
+        customers = parquet.ParquetFile(stream)
+        assert customers.metadata.num_rows == n_customers
+
+        table = customers.read()
+        assert str(table["last_name"][0]) == "Almeida"
+        assert str(table["first_name"][0]) == "Roberto"
+        assert str(table["company"][0]) == "Riotur"
+        assert str(table["last_name"][-1]) == "Zimmermann"
+        assert str(table["first_name"][-1]) == "Fynn"
+        assert str(table["company"][-1]) == "None"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,105 @@
+"""Tests for the data7.utils module."""
+
+import pytest
+
+from data7.app import (
+    Dataset,
+)
+from data7.config import settings
+from data7.utils import populate_datasets
+
+
+def test_populate_datasets(db_engine, monkeypatch):
+    """Test the populate_datasets function."""
+    employees_query = (
+        "SELECT "
+        "LastName as last_name, "
+        "FirstName as first_name, "
+        "city as city "
+        "FROM Employee"
+    )
+
+    customers_query = (
+        "SELECT "
+        "LastName as last_name, "
+        "FirstName as first_name, "
+        "Company as company "
+        "FROM Customer"
+    )
+
+    monkeypatch.setattr(
+        settings,
+        "datasets",
+        [
+            {
+                "basename": "employees",
+                "query": employees_query,
+            },
+            {
+                "basename": "customers",
+                "query": customers_query,
+            },
+        ],
+    )
+    datasets = populate_datasets(db_engine)
+    assert datasets == [
+        Dataset(
+            basename="employees",
+            query=employees_query,
+        ),
+        Dataset(
+            basename="customers",
+            query=customers_query,
+        ),
+    ]
+
+
+def test_populate_datasets_with_invalid_query(db_engine, monkeypatch):
+    """Test the populate_datasets function when user defined an invalid query."""
+    employees_query = (
+        "SELECT "
+        "LastName as last_name, "
+        "FirstName as first_name, "
+        "city as city "
+        "FROM Employee "
+        "WHERE LastName = 'Doe'"
+    )
+
+    monkeypatch.setattr(
+        settings,
+        "datasets",
+        [
+            {
+                "basename": "employees",
+                "query": employees_query,
+            },
+        ],
+    )
+
+    datasets = populate_datasets(db_engine)
+    assert len(datasets) == 0
+
+    employees_query = (
+        "SELECT "
+        "LastName as last_name, "
+        "FirstName as first_name, "
+        "city as city "
+        "FROM Employe "
+        "WHERE LastName = 'Doe'"
+    )
+
+    monkeypatch.setattr(
+        settings,
+        "datasets",
+        [
+            {
+                "basename": "employees",
+                "query": employees_query,
+            },
+        ],
+    )
+
+    with pytest.raises(
+        ValueError, match="Dataset 'employees' query failed, maybe SQL is invalid"
+    ):
+        populate_datasets(db_engine)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,8 @@
 
 import pytest
 
-from data7.app import (
-    Dataset,
-)
 from data7.config import settings
+from data7.models import Dataset
 from data7.utils import populate_datasets
 
 


### PR DESCRIPTION
## Purpose

It would be nice to be able to extract SQL data using the CLI:

```sh
data7 stream --parquet invoices > /data/export/2025/05/02-invoices.parquet
```

## Proposal

- [x] remove streamer/app dependency
- [x] add `stream` CLI command
- [x] update documentation
