### PR TITLE
🔖(minor) bump release to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.10.0] - 2025-05-09
+
 ### Added
 
 - Stream datasets from the CLI using the new `stream` command
@@ -127,7 +129,8 @@ and this project adheres to
 - Implement CSV output format
 - Implement Parquet output format
 
-[unreleased]: https://github.com/jmaupetit/data7/compare/v0.9.0...main
+[unreleased]: https://github.com/jmaupetit/data7/compare/v0.10.0...main
+[0.10.0]: https://github.com/jmaupetit/data7/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/jmaupetit/data7/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jmaupetit/data7/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jmaupetit/data7/compare/v0.6.0...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data7"
-version = "0.9.0"
+version = "0.10.0"
 description = "Data7 streams CSV/Parquet datasets over HTTP from SQL queries."
 authors = ["Julien Maupetit <julien@maupetit.net>"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Stream datasets from the CLI using the new `stream` command

### Changed

#### Dependencies

- Upgrade dynaconf to 3.2.11
- Upgrade pandas to 2.2.3
- Upgrade pyarrow to 20.0.0
- Upgrade pyinstrument to 5.0.1
- Upgrade sentry-sdk to 2.27.0
- Upgrade sqlalchemy to 2.0.40
- Upgrade starlette to 0.46.2
- Upgrade typer to 0.15.3
- Upgrade uvicorn to 0.34.2

## Purpose

Description...

## Proposal

Description...

- [ ] item 1...
- [ ] item 2...
