### PR TITLE
👷(github) add missing default workflow permissions

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches-ignore: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   fixup-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

Some CI workflows do not define default permissions.

## Proposal

Add `contents:read` default permission.
