### PR TITLE
🔖(patch) bump release to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-06-05
+
 ### Security
 
 - Upgrade starlette to 1.2.1
@@ -223,7 +225,8 @@ and this project adheres to
 - Implement CSV output format
 - Implement Parquet output format
 
-[unreleased]: https://github.com/jmaupetit/data7/compare/v1.0.1...main
+[unreleased]: https://github.com/jmaupetit/data7/compare/v1.0.2...main
+[1.0.2]: https://github.com/jmaupetit/data7/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/jmaupetit/data7/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/jmaupetit/data7/compare/v0.13.2...v1.0.0
 [0.13.2]: https://github.com/jmaupetit/data7/compare/v0.13.1...v0.13.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data7"
-version = "1.0.1"
+version = "1.0.2"
 description = "Data7 streams CSV/Parquet datasets over HTTP from SQL queries."
 authors = [
   {name="Julien Maupetit", email="julien@maupetit.net"},

--- a/uv.lock
+++ b/uv.lock
@@ -456,7 +456,7 @@ wheels = [
 
 [[package]]
 name = "data7"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "dynaconf" },


### PR DESCRIPTION
### Security

- Upgrade starlette to 1.2.1 ((CVE-2026-48710)[https://nvd.nist.gov/vuln/detail/CVE-2026-48710])
